### PR TITLE
Replace panic

### DIFF
--- a/src/bend.rs
+++ b/src/bend.rs
@@ -65,4 +65,7 @@ impl DstvElement for Bend {
             self.origin_x, self.origin_y, self.radius, self.radius, self.finish_x, self.finish_y
         )
     }
+    fn as_any(&self) -> &dyn core::any::Any {
+        self
+    }
 }

--- a/src/bend.rs
+++ b/src/bend.rs
@@ -32,12 +32,12 @@ impl DstvElement for Bend {
     /// A Result containing either a Bend or a &'static str.
     fn from_str(line: &str) -> Result<Self, ParseDstvError> {
         let mut iter = line.split_whitespace();
-        let origin_x = get_f64_from_str(iter.next(), "origin_x");
-        let origin_y = get_f64_from_str(iter.next(), "origin_y");
-        let angle = get_f64_from_str(iter.next(), "angle");
-        let radius = get_f64_from_str(iter.next(), "radius");
-        let finish_x = get_f64_from_str(iter.next(), "finish_x");
-        let finish_y = get_f64_from_str(iter.next(), "finish_y");
+        let origin_x = get_f64_from_str(iter.next(), "origin_x")?;
+        let origin_y = get_f64_from_str(iter.next(), "origin_y")?;
+        let angle = get_f64_from_str(iter.next(), "angle")?;
+        let radius = get_f64_from_str(iter.next(), "radius")?;
+        let finish_x = get_f64_from_str(iter.next(), "finish_x")?;
+        let finish_y = get_f64_from_str(iter.next(), "finish_y")?;
         Ok(Self {
             angle,
             radius,

--- a/src/border.rs
+++ b/src/border.rs
@@ -170,6 +170,9 @@ impl DstvElement for OuterBorder {
     fn get_facing(&self) -> &PartFace {
         &self.contour[0].fl_code
     }
+    fn as_any(&self) -> &dyn core::any::Any {
+        self
+    }
 }
 
 impl DstvElement for InnerBorder {
@@ -190,5 +193,8 @@ impl DstvElement for InnerBorder {
 
     fn get_facing(&self) -> &PartFace {
         &self.contour[0].fl_code
+    }
+    fn as_any(&self) -> &dyn core::any::Any {
+        self
     }
 }

--- a/src/cut.rs
+++ b/src/cut.rs
@@ -32,12 +32,12 @@ impl DstvElement for Cut {
                 "Illegal data vector format (SC): too short",
             ));
         }
-        let sp_point_x = get_f64_from_str(iter.next(), "sp_point_x");
-        let sp_point_y = get_f64_from_str(iter.next(), "sp_point_y");
-        let sp_point_z = get_f64_from_str(iter.next(), "sp_point_z");
-        let nor_vec_x = get_f64_from_str(iter.next(), "nor_vec_x");
-        let nor_vec_y = get_f64_from_str(iter.next(), "nor_vec_y");
-        let nor_vec_z = get_f64_from_str(iter.next(), "nor_vec_z");
+        let sp_point_x = get_f64_from_str(iter.next(), "sp_point_x")?;
+        let sp_point_y = get_f64_from_str(iter.next(), "sp_point_y")?;
+        let sp_point_z = get_f64_from_str(iter.next(), "sp_point_z")?;
+        let nor_vec_x = get_f64_from_str(iter.next(), "nor_vec_x")?;
+        let nor_vec_y = get_f64_from_str(iter.next(), "nor_vec_y")?;
+        let nor_vec_z = get_f64_from_str(iter.next(), "nor_vec_z")?;
         Ok(Self {
             nor_vec_x,
             nor_vec_y,

--- a/src/cut.rs
+++ b/src/cut.rs
@@ -68,4 +68,7 @@ impl DstvElement for Cut {
     fn get_facing(&self) -> &crate::prelude::PartFace {
         &crate::prelude::PartFace::Top
     }
+    fn as_any(&self) -> &dyn core::any::Any {
+        self
+    }
 }

--- a/src/dstv.rs
+++ b/src/dstv.rs
@@ -15,13 +15,24 @@ pub struct Dstv {
 impl Dstv {
     /// Creates a new Dstv struct from a file path
     /// # Arguments
-    /// * `file_path` - A string slice that holds the path to the file
+    /// * `file_path` - A string slice/path that holds the path to the file
     /// # Returns
     /// * A Result containing either a Dstv struct or a &'static str
-    pub fn from_file(file_path: &str) -> Result<Self, ParseDstvError> {
-        let lines = std::fs::read_to_string(file_path).expect("Unable to read file");
-
-        let elements = lines
+    pub fn from_file<P: AsRef<std::path::Path>>(file_path: P) -> Result<Self, ParseDstvError> {
+        let file_path = file_path.as_ref();
+        let file = std::fs::read_to_string(file_path).map_err(|e| {
+            ParseDstvError::new(&format!("Unable to read file: `{file_path:#?}`\t{e}"))
+        })?;
+        Self::from_str(file)
+    }
+    /// Creates a new Dstv struct from an already read file
+    /// # Arguments
+    /// * `file` - The file as read to String
+    /// # Returns
+    /// * A Result containing either a Dstv struct or a &'static str
+    pub fn from_str<S: AsRef<str>>(file: S) -> Result<Self, ParseDstvError> {
+        let elements = file
+            .as_ref()
             .lines()
             .filter(|line| !line.trim().starts_with('*'))
             // create a tuple of (element_type, lines)

--- a/src/dstv_element.rs
+++ b/src/dstv_element.rs
@@ -1,14 +1,21 @@
+use std::fmt::Debug;
+
 use crate::prelude::PartFace;
 
-#[derive(Debug)]
+#[derive(Debug, PartialEq)]
 pub struct ParseDstvError {
     message: String,
 }
 
 impl ParseDstvError {
-    pub fn new(message: &str) -> ParseDstvError {
+    pub fn from_err<S: AsRef<str>, E: Debug>(message: S, error: E) -> Self {
+        Self {
+            message: format!("`{}`:\t`{:#?}`", message.as_ref(), error),
+        }
+    }
+    pub fn new<S: AsRef<str>>(message: S) -> ParseDstvError {
         ParseDstvError {
-            message: message.to_string(),
+            message: message.as_ref().to_string(),
         }
     }
 }

--- a/src/dstv_element.rs
+++ b/src/dstv_element.rs
@@ -53,4 +53,5 @@ pub trait DstvElement {
     /// Returns the flange code of the element.
     /// This is used to determine the side of the element that is drawn.
     fn get_facing(&self) -> &PartFace;
+    fn as_any(&self) -> &dyn core::any::Any;
 }

--- a/src/hole.rs
+++ b/src/hole.rs
@@ -23,11 +23,11 @@ impl DstvElement for Hole {
     /// A `Result` containing either a `Hole` or an error message
     fn from_str(line: &str) -> Result<Self, ParseDstvError> {
         let mut iter = line.split_whitespace();
-        let fl_code = PartFace::from_str(iter.next().unwrap()).expect("Invalid flange code");
-        let x_coord = get_f64_from_str(iter.next(), "x_coord");
-        let y_coord = get_f64_from_str(iter.next(), "y_coord");
-        let diameter = get_f64_from_str(iter.next(), "diameter");
-        let depth = get_f64_from_str(iter.next(), "depth");
+        let fl_code = PartFace::from_str(iter.next().ok_or(ParseDstvError::new("No Hole Found"))?)?;
+        let x_coord = get_f64_from_str(iter.next(), "x_coord")?;
+        let y_coord = get_f64_from_str(iter.next(), "y_coord")?;
+        let diameter = get_f64_from_str(iter.next(), "diameter")?;
+        let depth = get_f64_from_str(iter.next(), "depth")?;
         Ok(Self {
             diameter,
             depth,

--- a/src/hole.rs
+++ b/src/hole.rs
@@ -27,7 +27,7 @@ impl DstvElement for Hole {
         let x_coord = get_f64_from_str(iter.next(), "x_coord")?;
         let y_coord = get_f64_from_str(iter.next(), "y_coord")?;
         let diameter = get_f64_from_str(iter.next(), "diameter")?;
-        let depth = get_f64_from_str(iter.next(), "depth")?;
+        let depth = get_f64_from_str(iter.next(), "depth").unwrap_or_default();
         Ok(Self {
             diameter,
             depth,
@@ -55,5 +55,8 @@ impl DstvElement for Hole {
 
     fn get_facing(&self) -> &PartFace {
         &self.fl_code
+    }
+    fn as_any(&self) -> &dyn core::any::Any {
+        self
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,6 +12,8 @@ mod slot;
 
 use std::str::FromStr;
 
+use prelude::ParseDstvError;
+
 /// Re-export all the modules
 pub mod prelude {
     pub use crate::bend::*;
@@ -43,10 +45,7 @@ pub mod prelude {
 /// assert_eq!(validate_flange("x"), false);
 /// ```
 pub fn validate_flange(flange: &str) -> bool {
-    match part_face::PartFace::from_str(flange) {
-        Ok(_) => true,
-        Err(_) => false,
-    }
+    part_face::PartFace::from_str(flange).is_ok()
 }
 
 /// Get f64 from string and strips it of any non numeric characters
@@ -58,13 +57,13 @@ pub fn validate_flange(flange: &str) -> bool {
 /// # example
 /// ```
 /// use dstv::get_f64_from_str;
-/// assert_eq!(get_f64_from_str(Some("1.0s"), "test"), 1.0);
-/// assert_eq!(get_f64_from_str(Some("1.0u"), "test"), 1.0);
-/// assert_eq!(get_f64_from_str(Some("1.0o"), "test"), 1.0);
-/// assert_eq!(get_f64_from_str(Some("1.0"), "test"), 1.0);
-/// assert_eq!(get_f64_from_str(None, "test"), 0.0);
+/// assert_eq!(get_f64_from_str(Some("1.0s"), "test"), Ok(1.0));
+/// assert_eq!(get_f64_from_str(Some("1.0u"), "test"), Ok(1.0));
+/// assert_eq!(get_f64_from_str(Some("1.0o"), "test"), Ok(1.0));
+/// assert_eq!(get_f64_from_str(Some("1.0"), "test"), Ok(1.0));
+/// assert_eq!(get_f64_from_str(None, "test"), Ok(0.0));
 /// ```
-pub fn get_f64_from_str(line: Option<&str>, name: &str) -> f64 {
+pub fn get_f64_from_str(line: Option<&str>, name: &str) -> Result<f64, ParseDstvError> {
     match line {
         Some(x) => x
             .replace("s", "")
@@ -73,10 +72,10 @@ pub fn get_f64_from_str(line: Option<&str>, name: &str) -> f64 {
             .replace("u", "")
             .replace("o", "")
             .parse::<f64>()
-            .expect(&format!("{} not a f64: got {}", name, x)),
+            .map_err(|_| ParseDstvError::new(format!("`{name}` not a f64: got `{x}`"))),
         None => {
             println!("{} not found", name);
-            0.0
+            Ok(0.0)
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -73,9 +73,6 @@ pub fn get_f64_from_str(line: Option<&str>, name: &str) -> Result<f64, ParseDstv
             .replace("o", "")
             .parse::<f64>()
             .map_err(|_| ParseDstvError::new(format!("`{name}` not a f64: got `{x}`"))),
-        None => {
-            println!("{} not found", name);
-            Ok(0.0)
-        }
+        None => Ok(0.0),
     }
 }

--- a/src/numeration.rs
+++ b/src/numeration.rs
@@ -27,12 +27,15 @@ impl DstvElement for Numeration {
     /// A `Result` containing either a `Numeration` or an error message
     fn from_str(line: &str) -> Result<Self, ParseDstvError> {
         let mut iter = line.split_whitespace();
-        let fl_code = PartFace::from_str(iter.next().unwrap()).expect("Invalid flange code");
-        let x_coord = get_f64_from_str(iter.next(), "x_coord");
-        let y_coord = get_f64_from_str(iter.next(), "y_coord");
-        let angle = get_f64_from_str(iter.next(), "angle");
-        let letterheight = get_f64_from_str(iter.next(), "letterheight");
-        let text = iter.next().expect("Text element not found").to_string();
+        let fl_code = PartFace::from_str(iter.next().ok_or(ParseDstvError::new("No Hole Found"))?)?;
+        let x_coord = get_f64_from_str(iter.next(), "x_coord")?;
+        let y_coord = get_f64_from_str(iter.next(), "y_coord")?;
+        let angle = get_f64_from_str(iter.next(), "angle")?;
+        let letterheight = get_f64_from_str(iter.next(), "letterheight")?;
+        let text = iter
+            .next()
+            .ok_or(ParseDstvError::new("Text element not found"))?
+            .to_string();
 
         Ok(Self {
             angle,

--- a/src/numeration.rs
+++ b/src/numeration.rs
@@ -60,4 +60,7 @@ impl DstvElement for Numeration {
     fn get_facing(&self) -> &PartFace {
         &self.fl_code
     }
+    fn as_any(&self) -> &dyn core::any::Any {
+        self
+    }
 }

--- a/src/part_face.rs
+++ b/src/part_face.rs
@@ -3,9 +3,13 @@ use std::str::FromStr;
 
 #[derive(Debug, PartialEq, Eq, Hash, Clone)]
 pub enum PartFace {
+    /// The Front or `v` Face
     Front,
+    /// The Top or `o` Face
     Top,
+    /// The Bottom or `u` Face
     Bottom,
+    /// The Behind or `h` Face
     Behind,
 }
 

--- a/src/part_face.rs
+++ b/src/part_face.rs
@@ -1,3 +1,4 @@
+use crate::prelude::ParseDstvError;
 use std::str::FromStr;
 
 #[derive(Debug, PartialEq, Eq, Hash, Clone)]
@@ -9,15 +10,16 @@ pub enum PartFace {
 }
 
 impl FromStr for PartFace {
-    type Err = ();
+    type Err = ParseDstvError;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let s = s.trim();
         match s {
             "v" => Ok(PartFace::Front),
             "o" => Ok(PartFace::Top),
             "u" => Ok(PartFace::Bottom),
             "h" => Ok(PartFace::Behind),
-            _ => Err(()),
+            _ => Err(ParseDstvError::new(format!("Invalid Face: {s}"))),
         }
     }
 }

--- a/src/slot.rs
+++ b/src/slot.rs
@@ -32,14 +32,14 @@ impl DstvElement for Slot {
     /// A `Result` containing either a `Slot` or an error message
     fn from_str(line: &str) -> Result<Self, ParseDstvError> {
         let mut iter = line.split_whitespace();
-        let fl_code = PartFace::from_str(iter.next().unwrap()).expect("Invalid flange code");
-        let x_coord = get_f64_from_str(iter.next(), "x_coord");
-        let y_coord = get_f64_from_str(iter.next(), "y_coord");
-        let diameter = get_f64_from_str(iter.next(), "diameter");
-        let depth = get_f64_from_str(iter.next(), "depth");
-        let slot_length = get_f64_from_str(iter.next(), "slot_length");
-        let slot_width = get_f64_from_str(iter.next(), "slot_width");
-        let angle = get_f64_from_str(iter.next(), "angle");
+        let fl_code = PartFace::from_str(iter.next().ok_or(ParseDstvError::new("No Slot Found"))?)?;
+        let x_coord = get_f64_from_str(iter.next(), "x_coord")?;
+        let y_coord = get_f64_from_str(iter.next(), "y_coord")?;
+        let diameter = get_f64_from_str(iter.next(), "diameter")?;
+        let depth = get_f64_from_str(iter.next(), "depth")?;
+        let slot_length = get_f64_from_str(iter.next(), "slot_length")?;
+        let slot_width = get_f64_from_str(iter.next(), "slot_width")?;
+        let angle = get_f64_from_str(iter.next(), "angle")?;
         Ok(Self {
             angle,
             slot_length,

--- a/src/slot.rs
+++ b/src/slot.rs
@@ -73,4 +73,7 @@ impl DstvElement for Slot {
     fn get_facing(&self) -> &PartFace {
         &self.fl_code
     }
+    fn as_any(&self) -> &dyn core::any::Any {
+        self
+    }
 }

--- a/tests/f64_parser.rs
+++ b/tests/f64_parser.rs
@@ -4,10 +4,10 @@ mod tests {
 
     #[test]
     fn test_f64_parsing() {
-        assert_eq!(get_f64_from_str(Some("1.0s"), "test"), 1.0);
-        assert_eq!(get_f64_from_str(Some("1.0u"), "test"), 1.0);
-        assert_eq!(get_f64_from_str(Some("1.0o"), "test"), 1.0);
-        assert_eq!(get_f64_from_str(Some("1.0"), "test"), 1.0);
-        assert_eq!(get_f64_from_str(None, "test"), 0.0);
+        assert_eq!(get_f64_from_str(Some("1.0s"), "test"), Ok(1.0));
+        assert_eq!(get_f64_from_str(Some("1.0u"), "test"), Ok(1.0));
+        assert_eq!(get_f64_from_str(Some("1.0o"), "test"), Ok(1.0));
+        assert_eq!(get_f64_from_str(Some("1.0"), "test"), Ok(1.0));
+        assert_eq!(get_f64_from_str(None, "test"), Ok(0.0));
     }
 }

--- a/tests/header.rs
+++ b/tests/header.rs
@@ -4,7 +4,6 @@ mod tests {
     #[test]
     fn read_header_p1() {
         let dstv = Dstv::from_file("./tests/data/P1.nc");
-        assert_eq!(dstv.is_ok(), true);
         let dstv = dstv.unwrap();
         assert_eq!(dstv.header.order_identification, "PROJECT-1");
         assert_eq!(dstv.header.drawing_identification, "0");
@@ -35,7 +34,6 @@ mod tests {
     #[test]
     fn read_header_rst37_2() {
         let dstv = Dstv::from_file("./tests/data/RST37-2.nc");
-        assert_eq!(dstv.is_ok(), true);
         let dstv = dstv.unwrap();
         assert_eq!(dstv.header.order_identification, "1");
         assert_eq!(dstv.header.drawing_identification, "1");
@@ -67,7 +65,6 @@ mod tests {
     #[test]
     fn read_header_pl01() {
         let dstv = Dstv::from_file("./tests/data/0008-PL0001.NC1");
-        assert_eq!(dstv.is_ok(), true);
         let dstv = dstv.unwrap();
         assert_eq!(dstv.header.order_identification, "0008");
         assert_eq!(dstv.header.drawing_identification, "NA");
@@ -98,7 +95,6 @@ mod tests {
     #[test]
     fn read_header_se04() {
         let dstv = Dstv::from_file("./tests/data/0008-SE0004.nc1");
-        assert_eq!(dstv.is_ok(), true);
         let dstv = dstv.unwrap();
         assert_eq!(dstv.header.order_identification, "0008");
         assert_eq!(dstv.header.drawing_identification, "NA");
@@ -129,7 +125,6 @@ mod tests {
     #[test]
     fn read_header_se08() {
         let dstv = Dstv::from_file("./tests/data/0008-SE0008.nc1");
-        assert_eq!(dstv.is_ok(), true);
         let dstv = dstv.unwrap();
         assert_eq!(dstv.header.order_identification, "0008");
         assert_eq!(dstv.header.drawing_identification, "NA");
@@ -160,7 +155,6 @@ mod tests {
     #[test]
     fn read_header_se09() {
         let dstv = Dstv::from_file("./tests/data/0008-SE0009.nc1");
-        assert_eq!(dstv.is_ok(), true);
         let dstv = dstv.unwrap();
         assert_eq!(dstv.header.order_identification, "0008");
         assert_eq!(dstv.header.drawing_identification, "NA");


### PR DESCRIPTION
Hello!  I've gone through and replaced the possible panics with Result, utilizing the `ParseDstvError` found in the crate.

This way, if a DSTV is invalid or throws an error, the calling code can handle it as they desire, rather than the program exiting.

Please let me know if you have any questions, and thank you, again, for this crate!