### PR TITLE
Update Header Collection to allow for blank notes

### DIFF
--- a/tests/data/0008-SE0009.nc1
+++ b/tests/data/0008-SE0009.nc1
@@ -21,9 +21,9 @@ ST
   0
   0
   
+  NoteOnLine2
   
-  
-  
+  NoteOnLine4
 AK
   v		945.73o		0.00		0.00								
   v		0.00o		0.00		0.00		-45		6				

--- a/tests/header.rs
+++ b/tests/header.rs
@@ -178,7 +178,8 @@ mod tests {
         assert_eq!(dstv.header.flange_start_cut, 0.0);
         assert_eq!(dstv.header.flange_end_cut, 0.0);
         assert_eq!(dstv.header.text1_info_on_piece, "");
-        assert_eq!(dstv.header.text2_info_on_piece, "");
+        assert_eq!(dstv.header.text2_info_on_piece, "NoteOnLine2");
         assert_eq!(dstv.header.text3_info_on_piece, "");
+        assert_eq!(dstv.header.text4_info_on_piece, "NoteOnLine4");
     }
 }


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Bug FIx

### :arrow_heading_down: What is the current behavior?
Headers with blank notes stop reading of the next notes

EX:
```
ST
**NC-DSTV - The Steel Detailer, C:\TSD 2016 Projects\0008\DSTV\0008-SE0009.nc1 ---  20/07/2016 9:27:17 PM
0008
  NA
  NA
0008-SE0009
  NA
  1
  100x100x6 SHS
  M
  1000
  100
  100
  6
  6
  7.5
  0
  0
  0
  0
  0
  0
  
  NoteOnLine2
  
  NoteOnLine4
```
The Empty Notes would stop the reading of the header.

### :new: What is the new behavior (if this is a feature change)?
Blank Note rows are allowed, and the header stops reading at 24 found lines

### :boom: Does this PR introduce a breaking change?
No

### :bug: Recommendations for testing
N/A

### :memo: Links to relevant issues/docs
N/A

### :thinking: Checklist before submitting

- I could not find style guides
- Documentation does not require updates

- [x] All projects build
- [ ] Follows style guide lines 
- [ ] Relevant documentation was updated
- [ ] Rebased onto current main
